### PR TITLE
Fixes #4 by allowing Parameterized Queries.

### DIFF
--- a/example.js
+++ b/example.js
@@ -5,11 +5,15 @@ var config = {
   password: 'rsPassword'
 };
 var rssql = require('redshift-sql')(config);
-var query = 'select * from myTable limit 10';
 
-rssql(query, function cb(err, result) {
+var query = 'select * from myTable where foo = $1 limit 10';
+var values = ['bar'];
+
+rssql(query, values, function cb(err, result) {
   if (err) {
     return console.error(err);
   }
   // do stuff
+  console.log('-- Result Rows --')
+  console.log(JSON.stringify(result.rows, null, 2));
 });

--- a/index.js
+++ b/index.js
@@ -12,13 +12,13 @@ module.exports = function init (config) {
   var conString = 'postgres://' + config.user + ':' + config.password + '@' + config.host +
   ':' + (config.port || 5439) + '/' + config.db;
 
-  function query (sql, cb) {
+  function query (sql, values, cb) {
     var client = new pg.Client(conString);
     client.connect(function (err) {
       if (err) {
         return cb(err);
       }
-      client.query(sql, function (err, result) {
+      client.query(sql, values, function (err, result) {
         client.end();
         cb(err, result);
       });


### PR DESCRIPTION
Also updated the example, but I didn't touch the version number.

This works because the underlying node-postgres query call can accept either a values array or callback function as the 2nd argument, both in the current version and the minimum version required by redshift-sql.